### PR TITLE
fixed time series embed

### DIFF
--- a/time-series.md
+++ b/time-series.md
@@ -4,5 +4,5 @@ layout: default
 
 # Time Series
 {% raw %}
-<iframe allowfullscreen="true" frameborder="no" border="0" marginwidth="0" marginheight="0" width="730" height="950" src="http://0.0.0.0:4000/time-series#CHN,NCH,fishing,false,true"></iframe>
+<iframe allowfullscreen="true" frameborder="no" border="0" marginwidth="0" marginheight="0" width="730" height="950" src="http://globalfishingwatch.io/time-series/#CHN,NCH,fishing,true,true"></iframe>
 {% endraw %}


### PR DESCRIPTION
Interactive map is not being displayed correctly in production since the iframe is pointing to a localhost environment: http://globalfishingwatch.org/research/dynamics-global-fishing-fleet-interactive/